### PR TITLE
Add support for Python 3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "moatless-tree-search"
-version = "0.0.4"
+version = "0.0.5"
 description = ""
 authors = [ "Albert Örwall <albert@moatless.ai>", "Antonis Antoniades <antonis@ucsb.edu>"]
 readme = "README.md"
@@ -21,7 +21,7 @@ target-version = "py310"
 extend-exclude = [ "tests", "evaluations", "notebooks",]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<=3.13"
+python = ">=3.10,<=3.14"
 
 pydantic = "^2.8.2"
 tiktoken = "^0.7.0"


### PR DESCRIPTION
This PR updates the Python version constraint in pyproject.toml to support Python 3.14. This allows the package to be installed on systems with Python 3.14 while maintaining compatibility with older versions (3.10-3.13).